### PR TITLE
Removed unused variable at Dispatcher.run method

### DIFF
--- a/dispatcher.js
+++ b/dispatcher.js
@@ -36,8 +36,6 @@ var Dispatcher = (function(){
   };
 
   Dispatcher.run = function(app, route) {
-    var reason;
-
     if (!route || typeof(route) !== "string") {
       throw new Error("You have to provide the route like site#index; " + Dispatcher.errorReason(route));
     }


### PR DESCRIPTION
Inside the `run` method had a undefined variable that was not being used at the scope of the function, and is the same variable of the errorReason method, I thought that is a little copy and paste error. Am I right? :smile_cat: 
