### PR TITLE
Add support to jquery 3.x

### DIFF
--- a/dispatcher.js
+++ b/dispatcher.js
@@ -34,9 +34,12 @@ var Dispatcher = (function(){
   };
 
   Dispatcher.init = function(app) {
-    $(document).on("ready page:load", function(){
+    var initFn = function(){
       Dispatcher.run(app, $("body").data("route"));
-    });
+    }
+
+    $(initFn);
+    $(document).on("page:load", initFn);
   };
 
   Dispatcher.run = function(app, route) {


### PR DESCRIPTION
$(document).on("ready") was removed, using $(fn) instead.

This change is backwards compatible with jQuery.